### PR TITLE
Fix colors on restart

### DIFF
--- a/src/SnakeGame.jsx
+++ b/src/SnakeGame.jsx
@@ -146,8 +146,8 @@ class SnakeGame extends React.Component {
       directionChanged: false,
       isGameOver: false,
       gameLoopTimeout: 50,
-      snakeColor: this.getRandomColor(),
-      appleColor: this.getRandomColor(),
+      snakeColor: this.props.snakeColor || this.getRandomColor(),
+      appleColor: this.props.appleColor || this.getRandomColor(),
       score: 0,
       newHighScore: false,
     })


### PR DESCRIPTION
Current behavior:
Snake and apple colors are randomized on restart, even if custom color props are passed in. 

Updated behavior:
Color props are used on restart if they are passed in. Otherwise, defaults to randomizing color(s) on restart.